### PR TITLE
Fix several bugs and minor refactors

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -139,7 +139,7 @@ lazy val core = crossProject
   .settings(name := "dagon-core")
   .settings(moduleName := "dagon-core")
   .settings(dagonSettings: _*)
-  .settings(mimaPreviousArtifacts := Set(previousArtifact("core")))
+  //.settings(mimaPreviousArtifacts := Set(previousArtifact("core"))) TODO re-enable after 0.2.0 is published
   .disablePlugins(JmhPlugin)
   .jsSettings(commonJsSettings: _*)
   .jsSettings(coverageEnabled := false)

--- a/core/src/main/scala/com/stripe/dagon/DependantGraph.scala
+++ b/core/src/main/scala/com/stripe/dagon/DependantGraph.scala
@@ -49,9 +49,19 @@ abstract class DependantGraph[T] {
 
   def fanOut(p: T): Option[Int] = dependantsOf(p).map { _.size }
 
+  def isTail(t: T): Boolean = allTails.contains(t)
+
   /**
    * Return all dependendants of a given node.
    * Does not include itself
    */
   def transitiveDependantsOf(p: T): List[T] = depthFirstOf(p)(graph)
+}
+
+object DependantGraph {
+  def apply[T](nodes0: List[T])(nfn: T => Iterable[T]): DependantGraph[T] =
+    new DependantGraph[T] {
+      def nodes = nodes0
+      def dependenciesOf(t: T) = nfn(t)
+    }
 }

--- a/core/src/main/scala/com/stripe/dagon/ExpressionDag.scala
+++ b/core/src/main/scala/com/stripe/dagon/ExpressionDag.scala
@@ -17,32 +17,44 @@
 
 package com.stripe.dagon
 
-sealed trait ExpressionDag[N[_]] { self =>
+sealed abstract class ExpressionDag[N[_]] { self =>
 
   /**
    * These have package visibility to test
    * the law that for all Expr, the node they
    * evaluate to is unique
    */
-  protected[dagon] def idToExp: HMap[Id, Expr[N, ?]]
-  protected def nodeToLiteral: FunctionK[N, Literal[N, ?]]
+  protected def idToExp: HMap[Id, Expr[N, ?]]
+  /**
+   * The set of roots that were added by addRoot.
+   * These are Ids that will always evaluate
+   * such that roots.forall(evaluateOption(_).isDefined)
+   */
   protected def roots: Set[Id[_]]
+  /**
+   * This is the next Id value which will be allocated
+   */
   protected def nextId: Int
+
+  /**
+   * Convert a N[T] to a Literal[T, N]
+   */
+  def toLiteral: FunctionK[N, Literal[N, ?]]
 
   private def copy(
       id2Exp: HMap[Id, Expr[N, ?]] = self.idToExp,
-      node2Literal: FunctionK[N, Literal[N, ?]] = self.nodeToLiteral,
+      node2Literal: FunctionK[N, Literal[N, ?]] = self.toLiteral,
       gcroots: Set[Id[_]] = self.roots,
       id: Int = self.nextId
   ): ExpressionDag[N] = new ExpressionDag[N] {
     def idToExp = id2Exp
     def roots = gcroots
-    def nodeToLiteral = node2Literal
+    def toLiteral = node2Literal
     def nextId = id
   }
 
   override def toString: String =
-    s"ExpressionDag(idToExp = $idToExp)"
+    s"ExpressionDag(idToExp = $idToExp, roots = $roots)"
 
   // This is a cache of Id[T] => Option[N[T]]
   private val idToN =
@@ -100,20 +112,16 @@ sealed trait ExpressionDag[N[_]] { self =>
    * the graph no longer changes.
    */
   def apply(rule: Rule[N]): ExpressionDag[N] = {
-    // for some reason, scala can't optimize this with tailrec
-    var prev: ExpressionDag[N] = null
-    var curr: ExpressionDag[N] = this
-    while (!(curr eq prev)) {
-      prev = curr
-      curr = curr.applyOnce(rule)
-    }
-    curr
-  }
 
-  /**
-   * Convert a N[T] to a Literal[T, N]
-   */
-  def toLiteral[T](n: N[T]): Literal[N, T] = nodeToLiteral(n)
+    @annotation.tailrec
+    def loop(d: ExpressionDag[N]): ExpressionDag[N] = {
+      val next = d.applyOnce(rule)
+      if (next eq d) next
+      else loop(next)
+    }
+
+    loop(this)
+  }
 
   /**
    * apply the rule at the first place that satisfies
@@ -145,58 +153,108 @@ sealed trait ExpressionDag[N[_]] { self =>
   }
 
   /**
+   * Apply a rule at most cnt times.
+   */
+  def applyMax(rule: Rule[N], cnt: Int): ExpressionDag[N] = {
+
+    @annotation.tailrec
+    def loop(d: ExpressionDag[N], cnt: Int): ExpressionDag[N] =
+      if (cnt <= 0) d
+      else {
+        val next = d.applyOnce(rule)
+        if (next eq d) d
+        else loop(next, cnt - 1)
+      }
+
+    loop(this, cnt)
+  }
+
+  /**
    * This is only called by ensure
    *
    * Note, Expr must never be a Var
    */
   private def addExp[T](node: N[T], exp: Expr[N, T]): (ExpressionDag[N], Id[T]) = {
     require(!exp.isVar)
-
-    find(node) match {
-      case None =>
-        val nodeId = Id[T](nextId)
-        (copy(id2Exp = idToExp + (nodeId -> exp), id = nextId + 1), nodeId)
-      case Some(id) =>
-        (this, id)
-    }
+    val nodeId = Id[T](nextId)
+    (copy(id2Exp = idToExp + (nodeId -> exp), id = nextId + 1), nodeId)
   }
 
   /**
-   * This finds the Id[T] in the current graph that is equivalent
+   * Find all the nodes currently in the graph
+   */
+  lazy val allNodes: Set[N[_]] = {
+    type Node = Either[Id[_], Expr[N, _]]
+    def deps(n: Node): List[Node] = n match {
+      case Right(Expr.Const(_)) => Nil
+      case Right(Expr.Var(id)) => Left(id) :: Nil
+      case Right(Expr.Unary(id, _)) => Left(id) :: Nil
+      case Right(Expr.Binary(id0, id1, _)) => Left(id0) :: Left(id1) :: Nil
+      case Left(id) => idToExp.get(id).map(Right(_): Node).toList
+    }
+    val all = Graphs.reflexiveTransitiveClosure(roots.toList.map(Left(_): Node))(deps _)
+
+    val evalMemo = Expr.evaluateMemo(idToExp)
+    all.iterator.collect { case Right(expr) => evalMemo(expr) }.toSet
+  }
+
+  /**
+   * This finds an Id[T] in the current graph that is equivalent
    * to the given N[T]
    */
   def find[T](node: N[T]): Option[Id[T]] =
     nodeToId.getOrElseUpdate(
       node, {
-
-        /*
-         * This method looks through linearly evaluating nodes
-         * until we find the given node. Keep a cache of
-         * Expr -> N open for the entire call
-         */
-        val evalExpr = Expr.evaluateMemo(idToExp)
-
-        val f = new FunctionK[HMap[Id, Expr[N, ?]]#Pair, Lambda[x => Option[Id[x]]]] {
-          // Make sure to return the original Id, not a Id -> Var -> Expr
-          def toFunction[T1] = {
-            case (thisId, expr) =>
-              if (!expr.isVar && node == evalExpr(expr)) Some(thisId) else None
-          }
-        }
-
-        idToExp.optionMap(f) match {
+        findAll(node).filterNot { id => idToExp(id).isVar } match {
           case Stream.Empty =>
+            // if the node is the in the graph it has at least
+            // one non-Var node
             None
-          case id #:: Stream.Empty =>
-            // this cast is safe if node == expr.evaluate(idToExp) implies types match
-            Some(id).asInstanceOf[Option[Id[T]]]
-          case _ =>
-            // we'd like to make this an error; there should only ever
-            // be zero or one ids for a node.
-            None //sys.error(s"logic error, should only be one mapping: $node -> $others")
+          case nonEmpty =>
+            // there can be duplicate ids. Consider this case:
+            // Id(0) -> Expr.Unary(Id(1), fn)
+            // Id(1) -> Expr.Const(n1)
+            // Id(2) -> Expr.Unary(Id(3), fn)
+            // Id(3) -> Expr.Const(n2)
+            //
+            // then, a rule replaces n1 and n2 both with n3 Then, we'd have
+            // Id(1) -> Var(Id(4))
+            // Id(4) -> Expr.Const(n3)
+            // Id(3) -> Var(Id(4))
+            //
+            // and now, Id(0) and Id(2) both point to non-Var nodes, but also
+            // both are equal
+
+            // Prefer to return a root Id, if there is one
+            val matchingRoots = nonEmpty.filter(roots)
+            if (matchingRoots.isEmpty) Some(nonEmpty.min)
+            else Some(matchingRoots.min)
         }
       }
     )
+
+  /**
+   * Nodes can have multiple ids in the graph, this gives all of them
+   */
+  def findAll[T](node: N[T]): Stream[Id[T]] = {
+    /*
+     * This method looks through linearly evaluating nodes
+     * until we find the given node. Keep a cache of
+     * Expr -> N open for the entire call
+     */
+    val evalExpr = Expr.evaluateMemo(idToExp)
+
+    val f = new FunctionK[HMap[Id, Expr[N, ?]]#Pair, Lambda[x => Option[Id[x]]]] {
+      def toFunction[T1] = {
+        case (thisId, expr) =>
+          if (node == evalExpr(expr)) Some(thisId) else None
+      }
+    }
+
+    // this cast is safe if node == expr.evaluate(idToExp) implies types match
+    idToExp.optionMap(f).asInstanceOf[Stream[Id[T]]]
+  }
+
 
   /**
    * This throws if the node is missing, use find if this is not
@@ -226,14 +284,16 @@ sealed trait ExpressionDag[N[_]] { self =>
              * check this property with the typesystem easily, check it here
              */
             require(n == node,
-                    s"Equality or nodeToLiteral is incorrect: nodeToLit($node) = Const($n)")
+                    s"Equality or toLiteral is incorrect: nodeToLit($node) = Const($n)")
             addExp(node, Expr.Const(n))
           case Literal.Unary(prev, fn) =>
             val (exp1, idprev) = ensure(prev.evaluate)
             exp1.addExp(node, Expr.Unary(idprev, fn))
           case Literal.Binary(n1, n2, fn) =>
-            val (exp1, id1) = ensure(n1.evaluate)
-            val (exp2, id2) = exp1.ensure(n2.evaluate)
+            // use a common memoized function on both branches
+            val evalLit = Literal.evaluateMemo[N]
+            val (exp1, id1) = ensure(evalLit(n1))
+            val (exp2, id2) = exp1.ensure(evalLit(n2))
             exp2.addExp(node, Expr.Binary(id1, id2, fn))
         }
     }
@@ -266,14 +326,6 @@ sealed trait ExpressionDag[N[_]] { self =>
       .map(fanOut)
       .getOrElse(0)
 
-  @annotation.tailrec
-  private def dependsOn(expr: Expr[N, _], node: N[_]): Boolean = expr match {
-    case Expr.Const(_) => false
-    case Expr.Var(id) => dependsOn(idToExp(id), node)
-    case Expr.Unary(id, _) => evaluate(id) == node
-    case Expr.Binary(id0, id1, _) => evaluate(id0) == node || evaluate(id1) == node
-  }
-
   /**
    * Returns 0 if the node is absent, which is true
    * use .contains(n) to check for containment
@@ -289,22 +341,46 @@ sealed trait ExpressionDag[N[_]] { self =>
    * Is this node a root of this graph
    */
   def isRoot(n: N[_]): Boolean =
-    roots(idOf(n))
+    findAll(n).exists(roots)
 
-  def contains(node: N[_]): Boolean = find(node).isDefined
+  /**
+   * Is this node in this DAG
+   */
+  def contains(node: N[_]): Boolean =
+    find(node).isDefined
 
   /**
    * list all the nodes that depend on the given node
    */
   def dependentsOf(node: N[_]): Set[N[_]] = {
+
+    @annotation.tailrec
+    def dependsOn(expr: Expr[N, _]): Boolean = expr match {
+      case Expr.Const(_) => false
+      case Expr.Var(id) => dependsOn(idToExp(id))
+      case Expr.Unary(id, _) => evaluate(id) == node
+      case Expr.Binary(id0, id1, _) => evaluate(id0) == node || evaluate(id1) == node
+    }
+
     // TODO, we can do a much better algorithm that builds this function
     // for all nodes in the dag
     val pointsToNode = new FunctionK[HMap[Id, Expr[N, ?]]#Pair, Lambda[x => Option[N[x]]]] {
       def toFunction[T] = {
-        case (id, expr) => if (dependsOn(expr, node)) Some(evaluate(id)) else None
+        case (id, expr) => if (dependsOn(expr)) Some(evaluate(id)) else None
       }
     }
     idToExp.optionMap(pointsToNode).toSet
+  }
+
+  /**
+   * Return all dependendants of a given node.
+   * Does not include itself
+   */
+  def transitiveDependentsOf(p: N[_]): Set[N[_]] = {
+    def nfn(n: N[Any]): List[N[Any]] =
+      dependentsOf(n).toList.asInstanceOf[List[N[Any]]]
+
+    Graphs.depthFirstOf(p.asInstanceOf[N[Any]])(nfn _).toSet
   }
 }
 
@@ -313,7 +389,7 @@ object ExpressionDag {
   def empty[N[_]](n2l: FunctionK[N, Literal[N, ?]]): ExpressionDag[N] =
     new ExpressionDag[N] {
       val idToExp = HMap.empty[Id, Expr[N, ?]]
-      val nodeToLiteral = n2l
+      val toLiteral = n2l
       val roots = Set.empty[Id[_]]
       val nextId = 0
     }

--- a/core/src/main/scala/com/stripe/dagon/Graphs.scala
+++ b/core/src/main/scala/com/stripe/dagon/Graphs.scala
@@ -8,7 +8,14 @@ object Graphs {
    * Return the depth first enumeration of reachable nodes,
    * NOT INCLUDING INPUT, unless it can be reached via neighbors
    */
-  def depthFirstOf[T](t: T)(nf: NeighborFn[T]): List[T] = {
+  def depthFirstOf[T](t: T)(nf: NeighborFn[T]): List[T] =
+    reflexiveTransitiveClosure(nf(t).toList)(nf)
+
+  /**
+   * All the nodes we can reach from this start, including
+   * the initial nodes
+   */
+  def reflexiveTransitiveClosure[T](start: List[T])(nf: NeighborFn[T]): List[T] = {
     @annotation.tailrec
     def loop(stack: List[T], deps: List[T], acc: Set[T]): List[T] =
       stack match {
@@ -20,7 +27,6 @@ object Graphs {
           val newDeps = if (acc(h)) deps else h :: deps
           loop(newStack, newDeps, acc + h)
       }
-    val start = nf(t).toList
     loop(start, start.distinct, start.toSet).reverse
   }
 

--- a/core/src/main/scala/com/stripe/dagon/Id.scala
+++ b/core/src/main/scala/com/stripe/dagon/Id.scala
@@ -11,3 +11,11 @@ package com.stripe.dagon
  * T is a phantom type used by the type system
  */
 final case class Id[T](id: Int)
+
+object Id {
+  implicit def idOrdering[T]: Ordering[Id[T]] =
+    new Ordering[Id[T]] {
+      def compare(a: Id[T], b: Id[T]) =
+        Integer.compare(a.id, b.id)
+    }
+}

--- a/core/src/main/scala/com/stripe/dagon/Rule.scala
+++ b/core/src/main/scala/com/stripe/dagon/Rule.scala
@@ -17,7 +17,14 @@ trait Rule[N[_]] { self =>
   // If the current rule cannot apply, then try the argument here
   def orElse(that: Rule[N]): Rule[N] = new Rule[N] {
     def apply[T](on: ExpressionDag[N]) = { n =>
-      self.apply(on)(n).orElse(that.apply(on)(n))
+      self.apply(on)(n) match {
+        case Some(n1) if n1 == n =>
+          // If the rule emits the same as input fall through
+          that.apply(on)(n)
+        case None =>
+          that.apply(on)(n)
+        case s@Some(_) => s
+      }
     }
 
     override def toString: String =

--- a/core/src/main/scala/com/stripe/dagon/Rule.scala
+++ b/core/src/main/scala/com/stripe/dagon/Rule.scala
@@ -24,3 +24,10 @@ trait Rule[N[_]] { self =>
       s"$self.orElse($that)"
   }
 }
+
+object Rule {
+  def empty[N[_]]: Rule[N] =
+    new Rule[N] {
+      def apply[T](on: ExpressionDag[N]) = { _ => None }
+    }
+}

--- a/core/src/test/scala/com/stripe/dagon/DataFlowTest.scala
+++ b/core/src/test/scala/com/stripe/dagon/DataFlowTest.scala
@@ -1,0 +1,439 @@
+package com.stripe.dagon
+
+import org.scalatest.FunSuite
+import org.scalacheck.{Arbitrary, Cogen, Gen}
+import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+
+object DataFlowTest {
+  sealed trait Flow[+T] {
+    def filter(fn: T => Boolean): Flow[T] =
+      optionMap(Flow.FilterFn(fn))
+
+    def map[U](fn: T => U): Flow[U] =
+      optionMap(Flow.MapFn(fn))
+
+    def optionMap[U](fn: T => Option[U]): Flow[U] =
+      Flow.OptionMapped(this, fn)
+
+    def concatMap[U](fn: T => TraversableOnce[U]): Flow[U] =
+      Flow.ConcatMapped(this, fn)
+
+    def ++[U >: T](that: Flow[U]): Flow[U] =
+      Flow.Merge(this, that)
+  }
+
+  object Flow {
+    def apply[T](it: Iterator[T]): Flow[T] = IteratorSource(it)
+
+    def dependenciesOf(f: Flow[Any]): List[Flow[Any]] =
+      f match {
+        case IteratorSource(_) => Nil
+        case OptionMapped(f, _) => f :: Nil
+        case ConcatMapped(f, _) => f :: Nil
+        case Merge(left, right) => left :: right :: Nil
+      }
+
+    def transitiveDeps(f: Flow[Any]): List[Flow[Any]] =
+      Graphs.reflexiveTransitiveClosure(List(f))(dependenciesOf _)
+
+    case class IteratorSource[T](it: Iterator[T]) extends Flow[T]
+    case class OptionMapped[T, U](input: Flow[T], fn: T => Option[U]) extends Flow[U]
+    case class ConcatMapped[T, U](input: Flow[T], fn: T => TraversableOnce[U]) extends Flow[U]
+    case class Merge[T](left: Flow[T], right: Flow[T]) extends Flow[T]
+
+    def toLiteral: FunctionK[Flow, Literal[Flow, ?]] =
+      Memoize.functionK[Flow, Literal[Flow, ?]](new Memoize.RecursiveK[Flow, Literal[Flow, ?]] {
+        import Literal._
+
+        def toFunction[T] = {
+          case (it@IteratorSource(_), _) => Const(it)
+          case (o: OptionMapped[s, T], rec) => Unary(rec[s](o.input), { f: Flow[s] => OptionMapped(f, o.fn) })
+          case (c: ConcatMapped[s, T], rec) => Unary(rec[s](c.input), { f: Flow[s] => ConcatMapped(f, c.fn) })
+          case (m: Merge[s], rec) => Binary(rec(m.left), rec(m.right), { (l: Flow[s], r: Flow[s]) => Merge(l, r) })
+        }
+      })
+
+    /*
+     * use case class functions to preserve equality where possible
+     */
+    private case class FilterFn[A](fn: A => Boolean) extends Function1[A, Option[A]] {
+      def apply(a: A): Option[A] = if (fn(a)) Some(a) else None
+    }
+
+    private case class MapFn[A, B](fn: A => B) extends Function1[A, Option[B]] {
+      def apply(a: A): Option[B] = Some(fn(a))
+    }
+
+    private case class ComposedOM[A, B, C](fn1: A => Option[B], fn2: B => Option[C]) extends Function1[A, Option[C]] {
+      def apply(a: A): Option[C] = fn1(a).flatMap(fn2)
+    }
+    private case class ComposedCM[A, B, C](fn1: A => TraversableOnce[B], fn2: B => TraversableOnce[C]) extends Function1[A, TraversableOnce[C]] {
+      def apply(a: A): TraversableOnce[C] = fn1(a).flatMap(fn2)
+    }
+    private case class OptionToConcatFn[A, B](fn: A => Option[B]) extends Function1[A, TraversableOnce[B]] {
+      def apply(a: A): TraversableOnce[B] = fn(a) match {
+        case Some(a) => Iterator.single(a)
+        case None => Iterator.empty
+      }
+    }
+
+    /**
+     * f.optionMap(fn1).optionMap(fn2) == f.optionMap { t => fn1(t).flatMap(fn2) }
+     * we use object to get good toString for debugging
+     */
+    object composeOptionMapped extends PartialRule[Flow] {
+      def applyWhere[T](on: ExpressionDag[Flow]) = {
+        case (OptionMapped(inner @ OptionMapped(s, fn0), fn1)) if on.fanOut(inner) == 1 =>
+          OptionMapped(s, ComposedOM(fn0, fn1))
+      }
+    }
+
+    /**
+     * f.concatMap(fn1).concatMap(fn2) == f.concatMap { t => fn1(t).flatMap(fn2) }
+     */
+    object composeConcatMap extends PartialRule[Flow] {
+      def applyWhere[T](on: ExpressionDag[Flow]) = {
+        case (ConcatMapped(inner @ ConcatMapped(s, fn0), fn1)) if on.fanOut(inner) == 1 =>
+          ConcatMapped(s, ComposedCM(fn0, fn1))
+      }
+    }
+
+    /**
+     * (a ++ b).concatMap(fn) == (a.concatMap(fn) ++ b.concatMap(fn))
+     * (a ++ b).optionMap(fn) == (a.optionMap(fn) ++ b.optionMap(fn))
+     */
+    object mergePullDown extends PartialRule[Flow] {
+      def applyWhere[T](on: ExpressionDag[Flow]) = {
+        case (ConcatMapped(merge @ Merge(a, b), fn)) if on.fanOut(merge) == 1 =>
+          a.concatMap(fn) ++ b.concatMap(fn)
+        case (OptionMapped(merge @ Merge(a, b), fn)) if on.fanOut(merge) == 1 =>
+          a.optionMap(fn) ++ b.optionMap(fn)
+      }
+    }
+
+    /**
+     * we can convert optionMap to concatMap if we don't care about maintaining
+     * the knowledge about which fns potentially expand the size
+     */
+    object optionMapToConcatMap extends PartialRule[Flow] {
+      def applyWhere[T](on: ExpressionDag[Flow]) = {
+        case OptionMapped(of, fn) => ConcatMapped(of, OptionToConcatFn(fn))
+      }
+    }
+
+    /**
+     * right associate merges
+     */
+    object rightMerge extends PartialRule[Flow] {
+      def applyWhere[T](on: ExpressionDag[Flow]) = {
+        case Merge(left@Merge(a, b), c) if on.fanOut(left) == 1 =>
+          Merge(a, Merge(b, c))
+      }
+    }
+
+    /**
+     *  evaluate single fanout sources
+     */
+    object evalSource extends PartialRule[Flow] {
+      def applyWhere[T](on: ExpressionDag[Flow]) = {
+        case OptionMapped(src @ IteratorSource(it), fn) if on.fanOut(src) == 1 =>
+          IteratorSource(it.flatMap(fn(_).toIterator))
+        case ConcatMapped(src @ IteratorSource(it), fn) if on.fanOut(src) == 1 =>
+          IteratorSource(it.flatMap(fn))
+        case Merge(src1 @ IteratorSource(it1), src2 @ IteratorSource(it2)) if it1 != it2 && on.fanOut(src1) == 1 && on.fanOut(src2) == 1 =>
+          IteratorSource(it1 ++ it2)
+        case Merge(src1 @ IteratorSource(it1), src2 @ IteratorSource(it2)) if it1 == it2 && on.fanOut(src1) == 1 && on.fanOut(src2) == 1 =>
+          // we need to materialize the left
+          val left = it1.toStream
+          IteratorSource((left #::: left).iterator)
+      }
+    }
+
+    /**
+     * these are all optimization rules to simplify
+     */
+    val allRules: Rule[Flow] =
+      composeOptionMapped
+        .orElse(composeConcatMap)
+        .orElse(mergePullDown)
+        .orElse(rightMerge)
+        .orElse(evalSource)
+
+    val ruleGen: Gen[Rule[Flow]] = {
+      val allRules = List(composeOptionMapped, composeConcatMap, optionMapToConcatMap, mergePullDown, rightMerge, evalSource)
+      for {
+        n <- Gen.choose(0, allRules.size)
+        gen = if (n == 0) Gen.const(List(Rule.empty[Flow])) else Gen.pick(n, allRules)
+        rs <- gen
+      } yield rs.reduce { (r1: Rule[Flow], r2: Rule[Flow]) => r1.orElse(r2) }
+    }
+
+    implicit val arbRule: Arbitrary[Rule[Flow]] =
+      Arbitrary(ruleGen)
+
+    def genFlow[T](g: Gen[T])(implicit cogen: Cogen[T]): Gen[Flow[T]] = {
+      implicit val arb: Arbitrary[T] = Arbitrary(g)
+
+      def genSource: Gen[Flow[T]] =
+        Gen.listOf(g).map { l => Flow(l.iterator) }
+
+      /**
+       * We want to create DAGs, so we need to sometimes select a parent
+       */
+      def reachable(f: Flow[T]): Gen[Flow[T]] =
+        Gen.lzy(Gen.oneOf(Flow.transitiveDeps(f).asInstanceOf[List[Flow[T]]]))
+
+     val optionMap: Gen[Flow[T]] =
+        for {
+          parent <- Gen.lzy(genFlow(g))
+          fn <- implicitly[Arbitrary[T => Option[T]]].arbitrary
+        } yield parent.optionMap(fn)
+
+      val concatMap: Gen[Flow[T]] =
+        for {
+          parent <- Gen.lzy(genFlow(g))
+          fn <- implicitly[Arbitrary[T => List[T]]].arbitrary
+        } yield parent.concatMap(fn)
+
+      val merge: Gen[Flow[T]] =
+        for {
+          left <- Gen.lzy(genFlow(g))
+          right <- Gen.frequency((3, genFlow(g)), (2, reachable(left)))
+          swap <- Gen.choose(0, 1)
+          res = if (swap == 1) (right ++ left) else (left ++ right)
+        } yield res
+
+      Gen.frequency((3, genSource), (1, optionMap), (1, concatMap), (1, merge))
+    }
+
+    implicit def arbFlow[T: Arbitrary: Cogen]: Arbitrary[Flow[T]] =
+      Arbitrary(genFlow[T](implicitly[Arbitrary[T]].arbitrary))
+
+
+    def expDagGen[T: Cogen](g: Gen[T]): Gen[ExpressionDag[Flow]] = {
+      val empty = ExpressionDag.empty[Flow](toLiteral)
+
+      Gen.frequency((1, Gen.const(empty)), (10, genFlow(g).map { f => empty.addRoot(f)._1 }))
+    }
+
+    def arbExpDag[T: Arbitrary: Cogen]: Arbitrary[ExpressionDag[Flow]] =
+      Arbitrary(expDagGen[T](implicitly[Arbitrary[T]].arbitrary))
+  }
+}
+
+class DataFlowTest extends FunSuite {
+
+  implicit val generatorDrivenConfig =
+    PropertyCheckConfiguration(minSuccessful = 1000)
+    //PropertyCheckConfiguration(minSuccessful = 100)
+
+  import DataFlowTest._
+
+  test("basic test 1") {
+    val f1 = Flow((0 to 100).iterator)
+
+    val branch1 = f1.map(_ * 2).filter(_ % 6 != 0)
+    val branch2 = f1.map(_ * Int.MaxValue).filter(_ % 6 == 0)
+
+    val tail = (branch1 ++ branch2).map(_ / 3)
+
+    import Flow._
+
+    val res = ExpressionDag.applyRule(tail, toLiteral, mergePullDown.orElse(composeOptionMapped))
+
+    res match {
+      case Merge(OptionMapped(s1, fn1), OptionMapped(s2, fn2)) =>
+        assert(s1 == s2)
+      case other => fail(s"$other")
+    }
+  }
+
+  test("basic test 2") {
+    def it1: Iterator[Int] = (0 to 100).iterator
+    def it2: Iterator[Int] = (1000 to 2000).iterator
+
+    val f = Flow(it1).map(_ * 2) ++ Flow(it2).filter(_ % 7 == 0)
+
+    ExpressionDag.applyRule(f, Flow.toLiteral, Flow.allRules) match {
+      case Flow.IteratorSource(it) =>
+        assert(it.toList == (it1.map(_ * 2) ++ (it2.filter(_ % 7 == 0))).toList)
+      case nonSrc =>
+        fail(s"expected total evaluation $nonSrc")
+    }
+
+  }
+
+  test("fanOut matches") {
+
+    def law(f: Flow[Int], rule: Rule[Flow], maxApplies: Int) = {
+      val (dag, id) = ExpressionDag(f, Flow.toLiteral)
+
+      val optimizedDag = dag.applyMax(rule, maxApplies)
+      val optF = optimizedDag.evaluate(id)
+
+      val depGraph = DependantGraph[Flow[Any]](Flow.transitiveDeps(optF))(Flow.dependenciesOf _)
+
+      def fanOut(f: Flow[Any]): Int = {
+        val internal = depGraph.fanOut(f).getOrElse(0)
+        val external = if (depGraph.isTail(f)) 1 else 0
+        internal + external
+      }
+
+      assert(optimizedDag.fanOut(optF) == fanOut(optF))
+      assert(optimizedDag.isRoot(optF))
+      assert(depGraph.isTail(optF))
+    }
+
+    forAll(law(_, _, _))
+
+    /**
+     * Here we have a list of past regressions
+     */
+    val it1 = List(1, 2, 3).iterator
+    val fn1 = { i: Int => if (i % 2 == 0) Some(i + 1) else None }
+    val it2 = List(2, 3, 4).iterator
+    val it3 = List(3, 4, 5).iterator
+    val fn2 = { i: Int => None }
+    val fn3 = { i: Int => (0 to i) }
+
+    import Flow._
+
+    val g = ConcatMapped(Merge(OptionMapped(IteratorSource(it1), fn1),
+                               OptionMapped(Merge(IteratorSource(it2),IteratorSource(it3)), fn2)), fn3)
+    law(g, Flow.allRules, 2)
+  }
+
+  test("we either totally evaluate or have Iterators with fanOut") {
+
+    def law(f: Flow[Int]) = {
+      val (dag, id) = ExpressionDag(f, Flow.toLiteral)
+      val optDag = dag(Flow.allRules)
+      val optF = optDag.evaluate(id)
+
+      optF match {
+        case Flow.IteratorSource(_) => succeed
+        case nonEval =>
+          val depGraph = DependantGraph[Flow[Any]](Flow.transitiveDeps(nonEval))(Flow.dependenciesOf _)
+
+          val fansOut = depGraph
+            .nodes
+            .collect {
+              case src@Flow.IteratorSource(_) => src
+            }
+            .exists(depGraph.fanOut(_).get > 1)
+
+          assert(fansOut, s"should have fanout: $nonEval")
+      }
+    }
+
+    forAll(law _)
+  }
+
+  test("addRoot adds roots") {
+    implicit val dag = Flow.arbExpDag[Int]
+
+    forAll { (d: ExpressionDag[Flow], f: Flow[Int]) =>
+
+      val (next, id) = d.addRoot(f)
+      assert(next.isRoot(f))
+      assert(next.evaluate(id) == f)
+      assert(next.evaluate(next.idOf(f)) == f)
+    }
+  }
+
+  test("all ExpressionDag.allNodes agrees with Flow.transitiveDeps") {
+    forAll { (f: Flow[Int], rule: Rule[Flow], max: Int) =>
+      val (dag, id) = ExpressionDag(f, Flow.toLiteral)
+
+      val optimizedDag = dag.applyMax(rule, max)
+
+      val optF = optimizedDag.evaluate(id)
+      assert(optimizedDag.allNodes == Flow.transitiveDeps(optF).toSet, s"optimized: $optF $optimizedDag")
+    }
+  }
+
+  test("ExpressionDag: findAll(n).forall(evaluate(_) == n)") {
+    forAll { (f: Flow[Int], rule: Rule[Flow], max: Int) =>
+      val (dag, id) = ExpressionDag(f, Flow.toLiteral)
+
+      val optimizedDag = dag.applyMax(rule, max)
+
+      optimizedDag.allNodes.foreach { n =>
+        optimizedDag.findAll(n).foreach { id =>
+          assert(optimizedDag.evaluate(id) == n, s"$id does not eval to $n in $optimizedDag")
+        }
+      }
+    }
+  }
+
+  test("apply the empty rule returns eq dag") {
+    implicit val dag = Flow.arbExpDag[Int]
+
+    forAll { (d: ExpressionDag[Flow]) =>
+      assert(d(Rule.empty[Flow]) eq d)
+    }
+  }
+
+
+  test("rules are idempotent") {
+    def law(f: Flow[Int], rule: Rule[Flow]) = {
+      val (dag, id) = ExpressionDag(f, Flow.toLiteral)
+      val optimizedDag = dag(rule)
+      val optF = optimizedDag.evaluate(id)
+
+      val (dag2, id2) = ExpressionDag(optF, Flow.toLiteral)
+      val optimizedDag2 = dag2(rule)
+      val optF2 = optimizedDag2.evaluate(id2)
+
+      assert(optF2 == optF, s"dag1: $optimizedDag -- dag1: $optimizedDag2")
+    }
+
+    forAll(law _)
+  }
+
+  test("dependentsOf matches DependantGraph.dependantsOf") {
+    forAll { (f: Flow[Int], rule: Rule[Flow], max: Int) =>
+      val (dag, id) = ExpressionDag(f, Flow.toLiteral)
+
+      val optimizedDag = dag.applyMax(rule, max)
+      val depGraph = DependantGraph[Flow[Any]](Flow.transitiveDeps(optimizedDag.evaluate(id)))(Flow.dependenciesOf _)
+
+      optimizedDag.allNodes.foreach { n =>
+        assert(optimizedDag.dependentsOf(n) == depGraph.dependantsOf(n).fold(Set.empty[Flow[Any]])(_.toSet))
+        assert(optimizedDag.transitiveDependentsOf(n) ==
+          depGraph.transitiveDependantsOf(n).toSet)
+      }
+    }
+  }
+
+  test("contains(n) is the same as allNodes.contains(n)") {
+    forAll { (f: Flow[Int], rule: Rule[Flow], max: Int, check: List[Flow[Int]]) =>
+      val (dag, _) = ExpressionDag(f, Flow.toLiteral)
+
+      val optimizedDag = dag.applyMax(rule, max)
+
+      (optimizedDag.allNodes.iterator ++ check.iterator).foreach { n =>
+        assert(optimizedDag.contains(n) == optimizedDag.allNodes(n), s"$n $optimizedDag")
+      }
+
+    }
+  }
+
+  test("all roots can be evaluated") {
+    forAll { (roots: List[Flow[Int]], rule: Rule[Flow], max: Int) =>
+      val dag = ExpressionDag.empty[Flow](Flow.toLiteral)
+
+      // This is pretty slow with tons of roots, take 10
+      val (finalDag, allRoots) = roots.take(10).foldLeft((dag, Set.empty[Id[Int]])) { case ((d, s), f) =>
+        val (nextDag, id) = d.addRoot(f)
+        (nextDag, s + id)
+      }
+
+      val optimizedDag = finalDag.applyMax(rule, max)
+
+      allRoots.foreach { id =>
+        assert(optimizedDag.evaluateOption(id).isDefined, s"$optimizedDag $id")
+      }
+    }
+  }
+}

--- a/core/src/test/scala/com/stripe/dagon/ExpressionDagTests.scala
+++ b/core/src/test/scala/com/stripe/dagon/ExpressionDagTests.scala
@@ -146,26 +146,6 @@ object ExpressionDagTests extends Properties("ExpressionDag") {
     noInc(noIncForm) && (noIncForm.evaluate == form.evaluate)
   }
 
-  /**
-   * This law is important for the rules to work as expected, and not have equivalent
-   * nodes appearing more than once in the Dag
-   */
-  property("Node structural equality implies Id equality") = forAll(genForm) { form =>
-    val (dag, id) = ExpressionDag(form, toLiteral)
-    dag.idToExp
-      .optionMap[BoolT](
-        new FunctionK[HMap[Id, Expr[Formula, ?]]#Pair, Lambda[x => Option[Boolean]]] {
-          def toFunction[T] = {
-            case (id, expr) =>
-              val node = expr.evaluate(dag.idToExp)
-              Some(dag.idOf(node) == id)
-            case _ =>
-              None
-          }
-        })
-      .forall(identity)
-  }
-
   // The normal Inc gen recursively calls the general dag Generator
   def genChainInc: Gen[Formula[Int]] =
     for {


### PR DESCRIPTION
* added a more complex example for the tests: Flow which is a very
simple data-flow style AST (similar to spark, etc...), but hopefully
complex enough to expose more bugs than the addition example.

* there was a bug with isRoot, this is fixed

* there was a bug in find which could result in needless extra Ids added
to the graph

* found a proof that the current approach (and maybe all approaches that
preserve all Ids) cannot maintain the invariant that each `N[_]` is the
result of evaluating at most one `Id[_]`. Which is to say
`evaluate[T](i: Id[T]): N[T]`
is a many to one function.

cc @non @erik-stripe 