### PR TITLE
Memoize Literal hashCode

### DIFF
--- a/core/src/main/scala/com/stripe/dagon/FunctionK.scala
+++ b/core/src/main/scala/com/stripe/dagon/FunctionK.scala
@@ -11,3 +11,10 @@ trait FunctionK[T[_], R[_]] {
 
   def toFunction[U]: T[U] => R[U]
 }
+
+object FunctionK {
+  def andThen[A[_], B[_], C[_]](first: FunctionK[A, B], second: FunctionK[B, C]): FunctionK[A, C] =
+    new FunctionK[A, C] {
+      def toFunction[U] = first.toFunction[U].andThen(second.toFunction[U])
+    }
+}

--- a/core/src/main/scala/com/stripe/dagon/Literal.scala
+++ b/core/src/main/scala/com/stripe/dagon/Literal.scala
@@ -10,15 +10,68 @@ sealed trait Literal[N[_], T] {
 
 object Literal {
 
-  case class Const[N[_], T](override val evaluate: N[T]) extends Literal[N, T]
+  case class Const[N[_], T](override val evaluate: N[T]) extends Literal[N, T] {
+    // cache hashCode since we hit it so much.
+    override val hashCode = (getClass, evaluate).hashCode
 
-  case class Unary[N[_], T1, T2](arg: Literal[N, T1], fn: N[T1] => N[T2]) extends Literal[N, T2]
+    // We often will cache the N[T] -> Literal[N, T] mapping, so we
+    // deal with referentially equal things, which can give cheap equality
+    override def equals(that: Any) =
+      that match {
+        case thatAR: AnyRef if thatAR eq this => true
+        case Const(thatE) => evaluate == thatE
+        case _ => false
+      }
+  }
+
+  case class Unary[N[_], T1, T2](arg: Literal[N, T1], fn: N[T1] => N[T2]) extends Literal[N, T2] {
+    // cache hashCode since we hit it so much.
+    override val hashCode = (getClass, arg, fn).hashCode
+
+    // We often will cache the N[T] -> Literal[N, T] mapping, so we
+    // deal with referentially equal things, which can give cheap equality
+    override def equals(that: Any) =
+      that match {
+        case thatAR: AnyRef if thatAR eq this => true
+        case Unary(thatA, thatfn) =>
+          // check the function first, before recursing on the literal
+          (thatfn == fn) && (arg == thatA)
+        case _ => false
+      }
+  }
 
   case class Binary[N[_], T1, T2, T3](arg1: Literal[N, T1],
                                       arg2: Literal[N, T2],
-                                      fn: (N[T1], N[T2]) => N[T3]) extends Literal[N, T3]
+                                      fn: (N[T1], N[T2]) => N[T3]) extends Literal[N, T3] {
+    // cache hashCode since we hit it so much.
+    override val hashCode = (getClass, arg1, arg2, fn).hashCode
 
-  case class Variadic[N[_], T1, T2](args: List[Literal[N, T1]], fn: List[N[T1]] => N[T2]) extends Literal[N, T2]
+    // We often will cache the N[T] -> Literal[N, T] mapping, so we
+    // deal with referentially equal things, which can give cheap equality
+    override def equals(that: Any) =
+      that match {
+        case thatAR: AnyRef if thatAR eq this => true
+        case Binary(thatA1, thatA2, thatfn) =>
+          // check the function first, before recursing on the literal
+          (thatfn == fn) && (arg1 == thatA1) && (arg1 == thatA2)
+        case _ => false
+      }
+  }
+
+  case class Variadic[N[_], T1, T2](args: List[Literal[N, T1]], fn: List[N[T1]] => N[T2]) extends Literal[N, T2]{
+    // cache hashCode since we hit it so much.
+    override val hashCode = (getClass, args, fn).hashCode
+    // We often will cache the N[T] -> Literal[N, T] mapping, so we
+    // deal with referentially equal things, which can give cheap equality
+    override def equals(that: Any) =
+      that match {
+        case thatAR: AnyRef if thatAR eq this => true
+        case Variadic(thatArgs, thatfn) =>
+          // check the function first, before recursing on the literal
+          (thatfn == fn) && (args == thatArgs)
+        case _ => false
+      }
+  }
 
   /**
    * This evaluates a literal formula back to what it represents


### PR DESCRIPTION
Literal.hashCode is coming up in a profiling code that uses Dagon. Since Binary nodes that actually merge the graph can cause duplicate work, hashCode can become exponential in the size of the graphs in pathological cases.

The ast you are optimizing should probably also consider similar optimizations since Dag calls these hashCode and equals quite a lot.