### PR TITLE
Improve Expr memoization in Dag and fix a regression

### DIFF
--- a/core/src/main/scala/com/stripe/dagon/Literal.scala
+++ b/core/src/main/scala/com/stripe/dagon/Literal.scala
@@ -53,7 +53,7 @@ object Literal {
         case thatAR: AnyRef if thatAR eq this => true
         case Binary(thatA1, thatA2, thatfn) =>
           // check the function first, before recursing on the literal
-          (thatfn == fn) && (arg1 == thatA1) && (arg1 == thatA2)
+          (thatfn == fn) && (arg1 == thatA1) && (arg2 == thatA2)
         case _ => false
       }
   }


### PR DESCRIPTION
1. until we change a Dag, we should cache the mapping from Expr to N rather than repeatedly compute it. Even evaluating one Expr is O(N), so we go from N^2 to N for the case of a rule that will not apply if you cache all evaluations.

2. we introduced a regression in equals in #19 