### PR TITLE
Make equals non-exponential

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -93,7 +93,7 @@ lazy val dagonSettings = Seq(
 ) ++ mimaDefaultSettings
 
 def previousArtifact(proj: String) =
-  "com.stripe" %% s"dagon-$proj" % "0.2.0"
+  "com.stripe" %% s"dagon-$proj" % "0.2.4"
 
 lazy val commonJvmSettings = Seq(
   testOptions in Test += Tests.Argument(TestFrameworks.ScalaTest, "-oDF"))

--- a/core/src/main/scala/com/stripe/dagon/Dag.scala
+++ b/core/src/main/scala/com/stripe/dagon/Dag.scala
@@ -331,6 +331,17 @@ sealed abstract class Dag[N[_]] { self =>
     }
 
   /**
+   * This is only called by ensure
+   *
+   * Note, Expr must never be a Var
+   */
+  private def addExp[T](node: N[T], exp: Expr[N, T]): (Dag[N], Id[T]) = {
+    require(!exp.isVar)
+    val nodeId = Id[T](nextId)
+    (copy(id2Exp = idToExp.updated(nodeId, exp), id = nextId + 1), nodeId)
+  }
+
+  /**
    * ensure the given literal node is present in the Dag
    * Note: it is important that at each moment, each node has
    * at most one id in the graph. Put another way, for all

--- a/core/src/main/scala/com/stripe/dagon/Dag.scala
+++ b/core/src/main/scala/com/stripe/dagon/Dag.scala
@@ -220,16 +220,33 @@ sealed abstract class Dag[N[_]] { self =>
     loop(this, cnt)
   }
 
-  /**
-   * This is only called by ensure
-   *
-   * Note, Expr must never be a Var
-   */
-  private def addExp[T](node: N[T], exp: Expr[N, T]): (Dag[N], Id[T]) = {
-    require(!exp.isVar)
-    val nodeId = Id[T](nextId)
-    (copy(id2Exp = idToExp.updated(nodeId, exp), id = nextId + 1), nodeId)
-  }
+  def depthOfId[A](i: Id[A]): Option[Int] =
+    depth(i)
+
+  def depthOf[A](n: N[A]): Option[Int] =
+    find(n).flatMap(depthOfId(_))
+
+  private val depth: Id[_] => Option[Int] =
+    Memoize.function[Id[_], Option[Int]] { (id, rec) =>
+      idToExp.get(id) match {
+        case None => None
+        case Some(Expr.Const(_)) => Some(0)
+        case Some(Expr.Var(id)) => rec(id)
+        case Some(Expr.Unary(id, _)) => rec(id).map(_ + 1)
+        case Some(Expr.Binary(id0, id1, _)) =>
+          for {
+            d0 <- rec(id0)
+            d1 <- rec(id1)
+          } yield math.max(d0, d1) + 1
+        case Some(Expr.Variadic(ids, _)) =>
+          ids.foldLeft(Option(0)) { (optD, id) =>
+            for {
+              d <- optD
+              d1 <- rec(id)
+            } yield math.max(d, d1) + 1
+          }
+      }
+    }
 
   /**
    * Find all the nodes currently in the graph
@@ -434,9 +451,9 @@ sealed abstract class Dag[N[_]] { self =>
     def dependsOn(expr: Expr[N, _]): Boolean = expr match {
       case Expr.Const(_) => false
       case Expr.Var(id) => sys.error(s"logic error: Var($id)")
-      case Expr.Unary(id, _) => evaluate(id) == node
-      case Expr.Binary(id0, id1, _) => evaluate(id0) == node || evaluate(id1) == node
-      case Expr.Variadic(ids, _) => ids.exists(evaluate(_) == node)
+      case Expr.Unary(id, _) => evaluatesTo(id, node)
+      case Expr.Binary(id0, id1, _) => evaluatesTo(id0, node) || evaluatesTo(id1, node)
+      case Expr.Variadic(ids, _) => ids.exists(evaluatesTo(_, node))
     }
 
     // TODO, we can do a much better algorithm that builds this function
@@ -450,6 +467,13 @@ sealed abstract class Dag[N[_]] { self =>
       }
     }
     idToExp.optionMap(pointsToNode).toSet
+  }
+
+  private def evaluatesTo[A, B](id: Id[A], n: N[B]): Boolean = {
+    val idN = evaluate(id)
+    // since we cache, reference equality will often work
+    val refEq = idN.asInstanceOf[AnyRef] eq id.asInstanceOf[AnyRef]
+    refEq || (idN == n)
   }
 
   /**

--- a/core/src/main/scala/com/stripe/dagon/Literal.scala
+++ b/core/src/main/scala/com/stripe/dagon/Literal.scala
@@ -6,6 +6,16 @@ package com.stripe.dagon
  */
 sealed trait Literal[N[_], T] {
   def evaluate: N[T] = Literal.evaluate(this)
+
+  /**
+   * Here we memoize as we check equality and always check reference
+   * equality first. This can dramatically improve performance on
+   * graphs that merge back often
+   */
+  override def equals(that: Any) = that match {
+    case thatF: Literal[_, _] => Literal.eqFn[N](RefPair(this, thatF.asInstanceOf[Literal[N, _]]))
+    case _ => false
+  }
 }
 
 object Literal {
@@ -13,31 +23,11 @@ object Literal {
   case class Const[N[_], T](override val evaluate: N[T]) extends Literal[N, T] {
     // cache hashCode since we hit it so much.
     override val hashCode = (getClass, evaluate).hashCode
-
-    // We often will cache the N[T] -> Literal[N, T] mapping, so we
-    // deal with referentially equal things, which can give cheap equality
-    override def equals(that: Any) =
-      that match {
-        case thatAR: AnyRef if thatAR eq this => true
-        case Const(thatE) => evaluate == thatE
-        case _ => false
-      }
   }
 
   case class Unary[N[_], T1, T2](arg: Literal[N, T1], fn: N[T1] => N[T2]) extends Literal[N, T2] {
     // cache hashCode since we hit it so much.
     override val hashCode = (getClass, arg, fn).hashCode
-
-    // We often will cache the N[T] -> Literal[N, T] mapping, so we
-    // deal with referentially equal things, which can give cheap equality
-    override def equals(that: Any) =
-      that match {
-        case thatAR: AnyRef if thatAR eq this => true
-        case Unary(thatA, thatfn) =>
-          // check the function first, before recursing on the literal
-          (thatfn == fn) && (arg == thatA)
-        case _ => false
-      }
   }
 
   case class Binary[N[_], T1, T2, T3](arg1: Literal[N, T1],
@@ -45,32 +35,11 @@ object Literal {
                                       fn: (N[T1], N[T2]) => N[T3]) extends Literal[N, T3] {
     // cache hashCode since we hit it so much.
     override val hashCode = (getClass, arg1, arg2, fn).hashCode
-
-    // We often will cache the N[T] -> Literal[N, T] mapping, so we
-    // deal with referentially equal things, which can give cheap equality
-    override def equals(that: Any) =
-      that match {
-        case thatAR: AnyRef if thatAR eq this => true
-        case Binary(thatA1, thatA2, thatfn) =>
-          // check the function first, before recursing on the literal
-          (thatfn == fn) && (arg1 == thatA1) && (arg2 == thatA2)
-        case _ => false
-      }
   }
 
   case class Variadic[N[_], T1, T2](args: List[Literal[N, T1]], fn: List[N[T1]] => N[T2]) extends Literal[N, T2]{
     // cache hashCode since we hit it so much.
     override val hashCode = (getClass, args, fn).hashCode
-    // We often will cache the N[T] -> Literal[N, T] mapping, so we
-    // deal with referentially equal things, which can give cheap equality
-    override def equals(that: Any) =
-      that match {
-        case thatAR: AnyRef if thatAR eq this => true
-        case Variadic(thatArgs, thatfn) =>
-          // check the function first, before recursing on the literal
-          (thatfn == fn) && (args == thatArgs)
-        case _ => false
-      }
   }
 
   /**
@@ -95,4 +64,30 @@ object Literal {
         case (Variadic(args, fn), rec) => fn(args.map(rec(_)))
       }
     })
+
+  /**
+   * Note that this is a def, not a val, so the cache only lives
+   * as long as a single outermost equality check
+   */
+  private def eqFn[N[_]]: Function[RefPair[Literal[N, _], Literal[N, _]], Boolean] =
+    Memoize.function[RefPair[Literal[N, _], Literal[N, _]], Boolean] {
+      case (pair, _) if pair.itemsEq => true
+      case (RefPair(Const(a), Const(b)), _) => a == b
+      case (RefPair(Unary(left, fa), Unary(right, fb)), rec) =>
+        (fa == fb) && rec(RefPair(left, right))
+      case (RefPair(Binary(lefta, righta, fa), Binary(leftb, rightb, fb)), rec) =>
+        (fa == fb) && rec(RefPair(lefta, leftb)) && rec(RefPair(righta, rightb))
+      case (RefPair(Variadic(argsa, fa), Variadic(argsb, fb)), rec) =>
+        @annotation.tailrec
+        def loop(left: List[Literal[N, _]], right: List[Literal[N, _]]): Boolean =
+          (left, right) match {
+            case (lh :: ltail, rh :: rtail) =>
+              rec(RefPair(lh, rh)) && loop(ltail, rtail)
+            case (Nil, Nil) => true
+            case _ => false
+          }
+
+        (fa == fb) && loop(argsa, argsb)
+      case other => false
+    }
 }

--- a/core/src/main/scala/com/stripe/dagon/RefPair.scala
+++ b/core/src/main/scala/com/stripe/dagon/RefPair.scala
@@ -1,0 +1,38 @@
+package com.stripe.dagon
+
+import scala.util.hashing.MurmurHash3
+/**
+ * A tuple2 that uses reference equality on items to do equality
+ * useful for caching the results of pair-wise functions on DAGs.
+ *
+ * Without this, you can easily get exponential complexity on
+ * recursion on DAGs.
+ */
+case class RefPair[A <: AnyRef, B <: AnyRef](_1: A, _2: B) {
+  private[this] var hashCodeVar: Int = 0
+
+  override def hashCode =
+    if (hashCodeVar != 0) hashCodeVar
+    else {
+      val hc0 = MurmurHash3.productHash(this)
+      // make sure we don't use 0, which we are using
+      // to signal that we have not computed yet
+      val hc = if (hc0 == 0) -1 else hc0
+      // Store it here, but without thread sync
+      // if there are two threads, they may both
+      // compute, but hashCode should be stable
+      // so that's fine
+      hashCodeVar = hc
+      hc
+    }
+
+  override def equals(that: Any) = that match {
+    case RefPair(thatA, thatB) => (_1 eq thatA) && (_2 eq thatB)
+    case _ => false
+  }
+
+  /**
+   * true if the left is referentially equal to the right
+   */
+  def itemsEq: Boolean = _1 eq _2
+}

--- a/core/src/main/scala/com/stripe/dagon/RefPair.scala
+++ b/core/src/main/scala/com/stripe/dagon/RefPair.scala
@@ -11,7 +11,7 @@ import scala.util.hashing.MurmurHash3
  */
 case class RefPair[A <: AnyRef, B <: AnyRef](_1: A, _2: B) {
 
-  lazy val hashCode: Int = MurmurHash3.productHash(this)
+  override lazy val hashCode: Int = MurmurHash3.productHash(this)
 
   override def equals(that: Any) = that match {
     case RefPair(thatA, thatB) => (_1 eq thatA) && (_2 eq thatB)

--- a/core/src/main/scala/com/stripe/dagon/RefPair.scala
+++ b/core/src/main/scala/com/stripe/dagon/RefPair.scala
@@ -1,6 +1,7 @@
 package com.stripe.dagon
 
 import scala.util.hashing.MurmurHash3
+
 /**
  * A tuple2 that uses reference equality on items to do equality
  * useful for caching the results of pair-wise functions on DAGs.
@@ -9,22 +10,8 @@ import scala.util.hashing.MurmurHash3
  * recursion on DAGs.
  */
 case class RefPair[A <: AnyRef, B <: AnyRef](_1: A, _2: B) {
-  private[this] var hashCodeVar: Int = 0
 
-  override def hashCode =
-    if (hashCodeVar != 0) hashCodeVar
-    else {
-      val hc0 = MurmurHash3.productHash(this)
-      // make sure we don't use 0, which we are using
-      // to signal that we have not computed yet
-      val hc = if (hc0 == 0) -1 else hc0
-      // Store it here, but without thread sync
-      // if there are two threads, they may both
-      // compute, but hashCode should be stable
-      // so that's fine
-      hashCodeVar = hc
-      hc
-    }
+  lazy val hashCode: Int = MurmurHash3.productHash(this)
 
   override def equals(that: Any) = that match {
     case RefPair(thatA, thatB) => (_1 eq thatA) && (_2 eq thatB)

--- a/core/src/test/scala/com/stripe/dagon/ExpressionDagTests.scala
+++ b/core/src/test/scala/com/stripe/dagon/ExpressionDagTests.scala
@@ -165,7 +165,7 @@ object DagTests extends Properties("Dag") {
   }
 
  //This is a bit noisey due to timing, but often passes
-   property("Evaluation is at most n^(2.5)") = {
+  property("Evaluation is at most n^(3.0)") = {
      def fibFormula(n: Int) = fib(Formula(1), Formula(1), n)(Sum(_, _))
 
      def check = {
@@ -182,7 +182,7 @@ object DagTests extends Properties("Dag") {
        (res40 == fib(1, 1, 40)(_ + _)) &&
        (res80 == fib(1, 1, 80)(_ + _)) &&
        (res160 == fib(1, 1, 160)(_ + _)) &&
-       (k < 2.5) // without properly memoized equality checks, this rule becomes exponential
+       (k < 3.0) // without properly memoized equality checks, this rule becomes exponential
      }
      check || check || check || check // try 4 times if needed to warm up the jit
    }


### PR DESCRIPTION
In a DAG, if we don't memoize our previous equality work, it can become exponential to check equality of two nodes.

Here we add a crude test that a applying an optimization is quadratic (not amazing, but much better than exponential).

We do this by caching during the life of a call which equality checks we have already performed.