### PR TITLE
Get tests passing on 2.13.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -45,7 +45,7 @@ lazy val dagonSettings = Seq(
     //"-Yno-adapted-args", //213
     "-Ywarn-dead-code",
     "-Ywarn-numeric-widen",
-    "-Ywarn-value-discard"//,
+    "-Ywarn-value-discard",
     //"-Xfuture" //213
   ),
   // HACK: without these lines, the console is basically unusable,
@@ -53,6 +53,7 @@ lazy val dagonSettings = Seq(
   // fatal errors).
   scalacOptions in (Compile, console) ~= { _.filterNot("-Xlint" == _) },
   scalacOptions in (Test, console) := (scalacOptions in (Compile, console)).value,
+  // use scala-2.12- and scala-2.13+ for per-version sources
   Compile / unmanagedSourceDirectories ++= scalaVersionSpecificFolders("main", baseDirectory.value, scalaVersion.value),
   Test / unmanagedSourceDirectories ++= scalaVersionSpecificFolders("test", baseDirectory.value, scalaVersion.value),
   // release stuff

--- a/build.sbt
+++ b/build.sbt
@@ -45,7 +45,7 @@ lazy val dagonSettings = Seq(
     //"-Yno-adapted-args", //213
     "-Ywarn-dead-code",
     "-Ywarn-numeric-widen",
-    "-Ywarn-value-discard",
+    "-Ywarn-value-discard"//,
     //"-Xfuture" //213
   ),
   // HACK: without these lines, the console is basically unusable,
@@ -53,7 +53,6 @@ lazy val dagonSettings = Seq(
   // fatal errors).
   scalacOptions in (Compile, console) ~= { _.filterNot("-Xlint" == _) },
   scalacOptions in (Test, console) := (scalacOptions in (Compile, console)).value,
-  // use scala-2.12- and scala-2.13+ for per-version sources
   Compile / unmanagedSourceDirectories ++= scalaVersionSpecificFolders("main", baseDirectory.value, scalaVersion.value),
   Test / unmanagedSourceDirectories ++= scalaVersionSpecificFolders("test", baseDirectory.value, scalaVersion.value),
   // release stuff

--- a/core/src/main/scala-2.12-/com/stripe/dagon/ScalaVersionCompat.scala
+++ b/core/src/main/scala-2.12-/com/stripe/dagon/ScalaVersionCompat.scala
@@ -4,6 +4,11 @@ object ScalaVersionCompat {
   type LazyList[+A] = scala.collection.immutable.Stream[A]
   val LazyList = scala.collection.immutable.Stream
 
+  type IterableOnce[+A] = scala.collection.TraversableOnce[A]
+
+  def iterateOnce[A](as: IterableOnce[A]): Iterator[A] =
+    as.toIterator
+
   def lazyList[A](as: A*): LazyList[A] =
     Stream(as: _*)
 

--- a/core/src/main/scala-2.12-/com/stripe/dagon/ScalaVersionCompat.scala
+++ b/core/src/main/scala-2.12-/com/stripe/dagon/ScalaVersionCompat.scala
@@ -1,0 +1,23 @@
+package com.stripe.dagon
+
+object ScalaVersionCompat {
+  type LazyList[+A] = scala.collection.immutable.Stream[A]
+  val LazyList = scala.collection.immutable.Stream
+
+  type IterableOnce[+A] = scala.collection.TraversableOnce[A]
+
+  def iterateOnce[A](as: IterableOnce[A]): Iterator[A] =
+    as.toIterator
+
+  def lazyList[A](as: A*): LazyList[A] =
+    Stream(as: _*)
+
+  def lazyListToIterator[A](lst: LazyList[A]): Iterator[A] =
+    lst.iterator
+
+  def lazyListFromIterator[A](it: Iterator[A]): LazyList[A] =
+    it.toStream
+
+  implicit val ieeeDoubleOrdering: Ordering[Double] =
+    Ordering.Double
+}

--- a/core/src/main/scala-2.12-/com/stripe/dagon/ScalaVersionCompat.scala
+++ b/core/src/main/scala-2.12-/com/stripe/dagon/ScalaVersionCompat.scala
@@ -4,11 +4,6 @@ object ScalaVersionCompat {
   type LazyList[+A] = scala.collection.immutable.Stream[A]
   val LazyList = scala.collection.immutable.Stream
 
-  type IterableOnce[+A] = scala.collection.TraversableOnce[A]
-
-  def iterateOnce[A](as: IterableOnce[A]): Iterator[A] =
-    as.toIterator
-
   def lazyList[A](as: A*): LazyList[A] =
     Stream(as: _*)
 

--- a/core/src/main/scala-2.13+/com/stripe/dagon/ScalaVersionCompat.scala
+++ b/core/src/main/scala-2.13+/com/stripe/dagon/ScalaVersionCompat.scala
@@ -1,0 +1,23 @@
+package com.stripe.dagon
+
+object ScalaVersionCompat {
+  type LazyList[+A] = scala.collection.immutable.LazyList[A]
+  val LazyList = scala.collection.immutable.LazyList
+
+  type IterableOnce[+A] = scala.collection.IterableOnce[A]
+
+  def iterateOnce[A](as: IterableOnce[A]): Iterator[A] =
+    as.iterator
+
+  def lazyList[A](as: A*): LazyList[A] =
+    LazyList(as: _*)
+
+  def lazyListToIterator[A](lst: LazyList[A]): Iterator[A] =
+    lst.iterator
+
+  def lazyListFromIterator[A](it: Iterator[A]): LazyList[A] =
+    LazyList.from(it)
+
+  implicit val ieeeDoubleOrdering: Ordering[Double] =
+    Ordering.Double.IeeeOrdering
+}

--- a/core/src/main/scala-2.13+/com/stripe/dagon/ScalaVersionCompat.scala
+++ b/core/src/main/scala-2.13+/com/stripe/dagon/ScalaVersionCompat.scala
@@ -4,6 +4,11 @@ object ScalaVersionCompat {
   type LazyList[+A] = scala.collection.immutable.LazyList[A]
   val LazyList = scala.collection.immutable.LazyList
 
+  type IterableOnce[+A] = scala.collection.IterableOnce[A]
+
+  def iterateOnce[A](as: IterableOnce[A]): Iterator[A] =
+    as.iterator
+
   def lazyList[A](as: A*): LazyList[A] =
     LazyList(as: _*)
 

--- a/core/src/main/scala-2.13+/com/stripe/dagon/ScalaVersionCompat.scala
+++ b/core/src/main/scala-2.13+/com/stripe/dagon/ScalaVersionCompat.scala
@@ -4,11 +4,6 @@ object ScalaVersionCompat {
   type LazyList[+A] = scala.collection.immutable.LazyList[A]
   val LazyList = scala.collection.immutable.LazyList
 
-  type IterableOnce[+A] = scala.collection.IterableOnce[A]
-
-  def iterateOnce[A](as: IterableOnce[A]): Iterator[A] =
-    as.iterator
-
   def lazyList[A](as: A*): LazyList[A] =
     LazyList(as: _*)
 

--- a/core/src/main/scala/com/stripe/dagon/Dag.scala
+++ b/core/src/main/scala/com/stripe/dagon/Dag.scala
@@ -623,13 +623,16 @@ sealed abstract class Dag[N[_]] extends Serializable { self =>
 
     def nextState(current: State): Option[State] =
       current match {
+        case (_, _, Nil, Nil, _) =>
+          None
         case (depth, _, Nil, nextBatch, seen) =>
           sort(nextBatch) match {
             case h :: tail =>
               val (nextBatch1, seen1) = computeNext(nextBatch, seen)
               Some((depth + 1, h, tail, nextBatch1, seen1))
             case Nil =>
-              None
+              // nextBatch has at least one item, and sorting preserves that
+              sys.error("impossible")
           }
         case (d, _, h :: tail, next, seen) =>
           Some((d, h, tail, next, seen))

--- a/core/src/main/scala/com/stripe/dagon/Dag.scala
+++ b/core/src/main/scala/com/stripe/dagon/Dag.scala
@@ -623,16 +623,13 @@ sealed abstract class Dag[N[_]] extends Serializable { self =>
 
     def nextState(current: State): Option[State] =
       current match {
-        case (_, _, Nil, Nil, _) =>
-          None
         case (depth, _, Nil, nextBatch, seen) =>
           sort(nextBatch) match {
             case h :: tail =>
               val (nextBatch1, seen1) = computeNext(nextBatch, seen)
               Some((depth + 1, h, tail, nextBatch1, seen1))
             case Nil =>
-              // nextBatch has at least one item, and sorting preserves that
-              sys.error("impossible")
+              None
           }
         case (d, _, h :: tail, next, seen) =>
           Some((d, h, tail, next, seen))

--- a/core/src/main/scala/com/stripe/dagon/HMap.scala
+++ b/core/src/main/scala/com/stripe/dagon/HMap.scala
@@ -18,6 +18,9 @@
 package com.stripe.dagon
 
 import java.io.Serializable
+
+import ScalaVersionCompat.{LazyList, lazyListFromIterator}
+
 /**
  * This is a weak heterogenous map. It uses equals on the keys,
  * so it is your responsibilty that if k: K[_] == k2: K[_] then
@@ -80,9 +83,9 @@ final class HMap[K[_], V[_]](protected val map: Map[K[_], V[_]]) extends Seriali
       case (k, w) if v == w => k.asInstanceOf[K[T]]
     }.toSet
 
-  def optionMap[R[_]](f: FunctionK[Pair, Lambda[x => Option[R[x]]]]): Stream[R[_]] = {
+  def optionMap[R[_]](f: FunctionK[Pair, Lambda[x => Option[R[x]]]]): LazyList[R[_]] = {
     val fnAny = f.toFunction[Any].andThen(_.iterator)
-    map.iterator.asInstanceOf[Iterator[(K[Any], V[Any])]].flatMap(fnAny).toStream
+    lazyListFromIterator(map.iterator.asInstanceOf[Iterator[(K[Any], V[Any])]].flatMap(fnAny))
   }
 
   def mapValues[V1[_]](f: FunctionK[V, V1]): HMap[K, V1] =

--- a/core/src/test/scala/com/stripe/dagon/DataFlowTest.scala
+++ b/core/src/test/scala/com/stripe/dagon/DataFlowTest.scala
@@ -5,7 +5,7 @@ import org.scalacheck.{Arbitrary, Cogen, Gen}
 import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks._
 import scala.util.control.TailCalls
 
-import ScalaVersionCompat.{IterableOnce, iterateOnce, lazyListFromIterator}
+import ScalaVersionCompat.lazyListFromIterator
 
 object DataFlowTest {
   sealed abstract class Flow[+T] extends Product {
@@ -18,7 +18,7 @@ object DataFlowTest {
     def optionMap[U](fn: T => Option[U]): Flow[U] =
       Flow.OptionMapped(this, fn)
 
-    def concatMap[U](fn: T => IterableOnce[U]): Flow[U] =
+    def concatMap[U](fn: T => Iterable[U]): Flow[U] =
       Flow.ConcatMapped(this, fn)
 
     def ++[U >: T](that: Flow[U]): Flow[U] =
@@ -107,7 +107,7 @@ object DataFlowTest {
 
     case class IteratorSource[T](it: Iterator[T]) extends Flow[T]
     case class OptionMapped[T, U](input: Flow[T], fn: T => Option[U]) extends Flow[U]
-    case class ConcatMapped[T, U](input: Flow[T], fn: T => IterableOnce[U]) extends Flow[U]
+    case class ConcatMapped[T, U](input: Flow[T], fn: T => Iterable[U]) extends Flow[U]
     case class Merge[T](left: Flow[T], right: Flow[T]) extends Flow[T]
     case class Merged[T](inputs: List[Flow[T]]) extends Flow[T]
     case class Tagged[A, T](input: Flow[T], tag: A) extends Flow[T]
@@ -197,14 +197,11 @@ object DataFlowTest {
         loop(a, fn1.asInstanceOf[Any => Option[Any]], fn2.asInstanceOf[Any => Option[C]])
       }
     }
-    private case class ComposedCM[A, B, C](fn1: A => IterableOnce[B], fn2: B => IterableOnce[C]) extends Function1[A, IterableOnce[C]] {
-      def apply(a: A): IterableOnce[C] = iterateOnce(fn1(a)).flatMap(fn2)
+    private case class ComposedCM[A, B, C](fn1: A => Iterable[B], fn2: B => Iterable[C]) extends Function1[A, Iterable[C]] {
+      def apply(a: A): Iterable[C] = fn1(a).flatMap(fn2)
     }
-    private case class OptionToConcatFn[A, B](fn: A => Option[B]) extends Function1[A, IterableOnce[B]] {
-      def apply(a: A): IterableOnce[B] = fn(a) match {
-        case Some(a) => Iterator.single(a)
-        case None => Iterator.empty
-      }
+    private case class OptionToConcatFn[A, B](fn: A => Option[B]) extends Function1[A, Iterable[B]] {
+      def apply(a: A): Iterable[B] = fn(a).toList
     }
 
     /**

--- a/core/src/test/scala/com/stripe/dagon/MemoizeTests.scala
+++ b/core/src/test/scala/com/stripe/dagon/MemoizeTests.scala
@@ -18,10 +18,11 @@ class MemoizeTests extends AnyFunSuite {
         }
       }
 
-    lazy val streamFib: Stream[Long] =
-      0L #:: 1L #:: (streamFib.zip(streamFib.drop(1)).map { case (a, b) => a + b })
+    def fib2(n: Int, x: Long, y: Long): Long =
+      if (n == 0) x
+      else fib2(n - 1, y, x + y)
 
-    assert(fib(100) == streamFib(100))
+    assert(fib(100) == fib2(100, 0L, 1L))
     assert(calls == 101)
   }
 


### PR DESCRIPTION
This PR gets Dagon cross-building for 2.13.

We use type aliases and methods to paper over pre- and post-2.13 changes, including `IterableOnce` and `LazyList`. This is similar to what we do in Paiges but a bit more involved.

This PR does disable a few compiler flags that aren't supported on 2.13. I could have hacked SBT to make them conditional but I didn't have the energy (but would be fine if someone else wanted to do this). I left them commented out for now.

cc @johnynek 